### PR TITLE
Feature/post preview images

### DIFF
--- a/__tests__/components/__snapshots__/post-preview-image.snapshot.js.snap
+++ b/__tests__/components/__snapshots__/post-preview-image.snapshot.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders PostPreviewImage unchanged 1`] = `
+<div>
+  <div
+    class="flex flex-col"
+  >
+    <div />
+    
+  </div>
+</div>
+`;

--- a/__tests__/components/__snapshots__/post.snapshot.js.snap
+++ b/__tests__/components/__snapshots__/post.snapshot.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders SocialsHorizontal unchanged 1`] = `
+<div>
+  <li
+    class="listItem"
+  >
+    <div
+      class="flex flex-col"
+    >
+      <div
+        class="justify-center items-center"
+      />
+      <a
+        href="/blog/undefined"
+      />
+    </div>
+    <br />
+    <small
+      class="subpreview"
+    >
+      
+      
+    </small>
+    <p />
+    <a
+      class="readMoreLink"
+      href="/blog/undefined"
+    >
+      Read More —&gt;
+    </a>
+  </li>
+</div>
+`;

--- a/__tests__/components/__snapshots__/post.snapshot.js.snap
+++ b/__tests__/components/__snapshots__/post.snapshot.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders Post unchanged 1`] = `
+<div>
+  <li
+    class="listItem"
+  >
+    <div
+      class="flex flex-col"
+    >
+      <div
+        class="justify-center items-center"
+      >
+        <div
+          class="flex flex-col"
+        >
+          <div />
+          
+        </div>
+      </div>
+      <a
+        href="/blog/undefined"
+      />
+    </div>
+    <br />
+    <small
+      class="subpreview"
+    >
+      
+      
+    </small>
+    <p />
+    <a
+      class="readMoreLink"
+      href="/blog/undefined"
+    >
+      Read More —&gt;
+    </a>
+  </li>
+</div>
+`;
+
 exports[`renders SocialsHorizontal unchanged 1`] = `
 <div>
   <li

--- a/__tests__/components/post-preview-image.snapshot.js
+++ b/__tests__/components/post-preview-image.snapshot.js
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import PostPreviewImage from '../../components/post-preview-image';
+
+it('renders PostPreviewImage unchanged', () => {
+    const { container } = render(<PostPreviewImage />);
+
+    expect(container).toMatchSnapshot()
+})

--- a/__tests__/components/post.snapshot.js
+++ b/__tests__/components/post.snapshot.js
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import Post from '../../components/post';
 
-it('renders SocialsHorizontal unchanged', () => {
+it('renders Post unchanged', () => {
     const { container } = render(<Post />);
 
     expect(container).toMatchSnapshot()

--- a/__tests__/components/post.snapshot.js
+++ b/__tests__/components/post.snapshot.js
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import Post from '../../components/post';
+
+it('renders SocialsHorizontal unchanged', () => {
+    const { container } = render(<Post />);
+
+    expect(container).toMatchSnapshot()
+})

--- a/components/post-preview-image.js
+++ b/components/post-preview-image.js
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
+const PostPreviewImage = ({
+    articleLink,
+    previewImage, 
+    previewImageWidth, 
+    previewImageHeight, 
+    previewImageCreditText,
+    previewImageCreditUrl,
+}) => {
+    return (
+        <div className="flex flex-col">
+            <div>
+            {(previewImage && previewImage !== undefined) 
+                && (previewImageWidth && previewImageWidth !== undefined) 
+                && (previewImageHeight && previewImageHeight !== undefined) ? 
+                (<Link href={articleLink}>
+                <Image src={previewImage} width={previewImageWidth} height={previewImageHeight} />
+                </Link>) 
+                : ''}
+            </div>
+            {(previewImageCreditText && previewImageCreditText !== undefined) 
+            && (previewImageCreditUrl && previewImageCreditUrl !== undefined) ? 
+            (<a href={previewImageCreditUrl}><span className="text-sm italic text-gray-400">{previewImageCreditText}</span></a>) 
+            : ''}
+        </div>
+    );
+};
+
+export default PostPreviewImage;

--- a/components/post.js
+++ b/components/post.js
@@ -3,19 +3,42 @@ import Image from 'next/image';
 import Date from './date'
 import utilStyles from '../styles/utils.module.css'
 
-export default function Post({ id, date, title, preview, previewImage, previewImageWidth, previewImageHeight, section }) {
+export default function Post({ 
+  id, 
+  date, 
+  title, 
+  preview, 
+  previewImage, 
+  previewImageWidth, 
+  previewImageHeight, 
+  previewImageCreditText,
+  previewImageCreditUrl,
+  section 
+}) {
+  const articleLink = `/blog/${id}`;
+
   return (
     <li className={utilStyles.listItem}>
       
       <div className="flex flex-col">
         <div className="justify-center items-center">
-          {(previewImage && previewImage !== undefined) 
-            && (previewImageWidth && previewImageWidth !== undefined) 
-            && (previewImageHeight && previewImageHeight !== undefined) ? 
-            (<Image src={previewImage} width={previewImageWidth} height={previewImageHeight} />) 
-            : ''}
+            <div className="flex flex-col">
+              <div>
+                {(previewImage && previewImage !== undefined) 
+                  && (previewImageWidth && previewImageWidth !== undefined) 
+                  && (previewImageHeight && previewImageHeight !== undefined) ? 
+                  (<a href={articleLink}>
+                    <Image src={previewImage} width={previewImageWidth} height={previewImageHeight} />
+                  </a>) 
+                  : ''}
+              </div>
+              {(previewImageCreditText && previewImageCreditText !== undefined) 
+                && (previewImageCreditUrl && previewImageCreditUrl !== undefined) ? 
+                (<a href={previewImageCreditUrl}><span className="text-sm italic text-gray-400">{previewImageCreditText}</span></a>) 
+                : ''}
+            </div>
         </div>
-        <Link href={`/blog/${id}`}>
+        <Link href={articleLink}>
           <a>{title}</a>
         </Link>
       </div>

--- a/components/post.js
+++ b/components/post.js
@@ -3,24 +3,31 @@ import Image from 'next/image';
 import Date from './date'
 import utilStyles from '../styles/utils.module.css'
 
-export default function Post({ id, date, title, preview, previewImage, section }) {
+export default function Post({ id, date, title, preview, previewImage, previewImageWidth, previewImageHeight, section }) {
   return (
     <li className={utilStyles.listItem}>
       
-      {/* If previewImage exists, then display it -- else, leave blank. */}
-      {previewImage && previewImage !== undefined ? 
-        (<Image src={previewImage} width="500" height="350" />) 
-        : ''}
+      <div className="flex flex-col">
+        <div className="justify-center items-center">
+          {(previewImage && previewImage !== undefined) 
+            && (previewImageWidth && previewImageWidth !== undefined) 
+            && (previewImageHeight && previewImageHeight !== undefined) ? 
+            (<Image src={previewImage} width={previewImageWidth} height={previewImageHeight} />) 
+            : ''}
+        </div>
+        <Link href={`/blog/${id}`}>
+          <a>{title}</a>
+        </Link>
+      </div>
 
-      <Link href={`/blog/${id}`}>
-        <a>{title}</a>
-      </Link>
       <br />
+
       <small className={utilStyles.subpreview}>
         {section ? (<text><a href={`/categories/${section}`}>{section}</a>&nbsp;&mdash;&nbsp;</text>) 
           : ''}
         {date ? (<Date dateString={date} />) : ''}
       </small>
+
       <p>{preview}</p>
 
       <Link href={`/blog/${id}`}>

--- a/components/post.js
+++ b/components/post.js
@@ -1,10 +1,17 @@
 import Link from 'next/link'
+import Image from 'next/image';
 import Date from './date'
 import utilStyles from '../styles/utils.module.css'
 
-export default function Post({ id, date, title, preview, section }) {
+export default function Post({ id, date, title, preview, previewImage, section }) {
   return (
     <li className={utilStyles.listItem}>
+      
+      {/* If previewImage exists, then display it -- else, leave blank. */}
+      {previewImage && previewImage !== undefined ? 
+        (<Image src={previewImage} width="500" height="350" />) 
+        : ''}
+
       <Link href={`/blog/${id}`}>
         <a>{title}</a>
       </Link>

--- a/components/post.js
+++ b/components/post.js
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import Image from 'next/image';
 import Date from './date'
 import utilStyles from '../styles/utils.module.css'
+import PostPreviewImage from './post-preview-image';
 
 export default function Post({ 
   id, 
@@ -22,21 +23,13 @@ export default function Post({
       
       <div className="flex flex-col">
         <div className="justify-center items-center">
-            <div className="flex flex-col">
-              <div>
-                {(previewImage && previewImage !== undefined) 
-                  && (previewImageWidth && previewImageWidth !== undefined) 
-                  && (previewImageHeight && previewImageHeight !== undefined) ? 
-                  (<a href={articleLink}>
-                    <Image src={previewImage} width={previewImageWidth} height={previewImageHeight} />
-                  </a>) 
-                  : ''}
-              </div>
-              {(previewImageCreditText && previewImageCreditText !== undefined) 
-                && (previewImageCreditUrl && previewImageCreditUrl !== undefined) ? 
-                (<a href={previewImageCreditUrl}><span className="text-sm italic text-gray-400">{previewImageCreditText}</span></a>) 
-                : ''}
-            </div>
+            <PostPreviewImage 
+              articleLink={articleLink}
+              previewImage={previewImage} 
+              previewImageWidth={previewImageWidth}
+              previewImageHeight={previewImageHeight} 
+              previewImageCreditText={previewImageCreditText}
+              previewImageCreditUrl={previewImageCreditUrl} />
         </div>
         <Link href={articleLink}>
           <a>{title}</a>

--- a/posts/2022/golang-debugger.mdx
+++ b/posts/2022/golang-debugger.mdx
@@ -6,6 +6,8 @@ published: true
 previewImage: "https://meddlin-web.s3.us-east-2.amazonaws.com/2022_go-debugger/delve-debugger.jpg"
 previewImageWidth: 500
 previewImageHeight: 350
+previewImageCreditText: "Image credit"
+previewImageCreditUrl: "https://klefz.se/2017/01/10/debugging-golang-tests-with-visual-studio-code-and-delve/"
 preview: |-
     Recently I started learning Go, and my first exercise forced me to setup 
     a debugger, revisit a common issue, and learn some of the tooling ecosystem

--- a/posts/2022/golang-debugger.mdx
+++ b/posts/2022/golang-debugger.mdx
@@ -3,6 +3,7 @@ date: "2022-09-28"
 title: "Setting up Delve for Golang Debugging, and a simple error"
 section: ''
 published: true
+previewImage: "https://meddlin-web.s3.us-east-2.amazonaws.com/2022_go-debugger/delve-debugger.jpg"
 preview: |-
     Recently I started learning Go, and my first exercise forced me to setup 
     a debugger, revisit a common issue, and learn some of the tooling ecosystem

--- a/posts/2022/golang-debugger.mdx
+++ b/posts/2022/golang-debugger.mdx
@@ -4,6 +4,8 @@ title: "Setting up Delve for Golang Debugging, and a simple error"
 section: ''
 published: true
 previewImage: "https://meddlin-web.s3.us-east-2.amazonaws.com/2022_go-debugger/delve-debugger.jpg"
+previewImageWidth: 500
+previewImageHeight: 350
 preview: |-
     Recently I started learning Go, and my first exercise forced me to setup 
     a debugger, revisit a common issue, and learn some of the tooling ecosystem


### PR DESCRIPTION
Blog posts already have a text preview, via the multi-line YAML. Should be able to accomplish this with an addition to the frontmatter metadata, and then use that property similar to how all of the others are used.

- Linked issues: 
  - https://github.com/meddlin/rushinglabs-blog/issues/36
  - https://github.com/meddlin/rushinglabs-blog/issues/56
- Discussion: 
  - https://github.com/meddlin/rushinglabs-blog/discussions/153