### PR TITLE
Code scan XSS fix: apply HTML escaping to filename routes

### DIFF
--- a/__tests__/components/__snapshots__/post.snapshot.js.snap
+++ b/__tests__/components/__snapshots__/post.snapshot.js.snap
@@ -39,36 +39,3 @@ exports[`renders Post unchanged 1`] = `
   </li>
 </div>
 `;
-
-exports[`renders SocialsHorizontal unchanged 1`] = `
-<div>
-  <li
-    class="listItem"
-  >
-    <div
-      class="flex flex-col"
-    >
-      <div
-        class="justify-center items-center"
-      />
-      <a
-        href="/blog/undefined"
-      />
-    </div>
-    <br />
-    <small
-      class="subpreview"
-    >
-      
-      
-    </small>
-    <p />
-    <a
-      class="readMoreLink"
-      href="/blog/undefined"
-    >
-      Read More —&gt;
-    </a>
-  </li>
-</div>
-`;

--- a/__tests__/components/__snapshots__/socials-horizontal.snapshot.js.snap
+++ b/__tests__/components/__snapshots__/socials-horizontal.snapshot.js.snap
@@ -17,7 +17,7 @@ exports[`renders SocialsHorizontal unchanged 1`] = `
           <img
             alt=""
             aria-hidden="true"
-            src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
             style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
           />
         </span>
@@ -43,7 +43,7 @@ exports[`renders SocialsHorizontal unchanged 1`] = `
           <img
             alt=""
             aria-hidden="true"
-            src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
             style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
           />
         </span>
@@ -69,7 +69,7 @@ exports[`renders SocialsHorizontal unchanged 1`] = `
           <img
             alt=""
             aria-hidden="true"
-            src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
             style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
           />
         </span>
@@ -95,7 +95,7 @@ exports[`renders SocialsHorizontal unchanged 1`] = `
           <img
             alt=""
             aria-hidden="true"
-            src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
             style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
           />
         </span>
@@ -121,7 +121,7 @@ exports[`renders SocialsHorizontal unchanged 1`] = `
           <img
             alt=""
             aria-hidden="true"
-            src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
             style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
           />
         </span>

--- a/__tests__/pages/[project]-index.snapshot.js
+++ b/__tests__/pages/[project]-index.snapshot.js
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import ProjectsSection from '../../pages/projects/[project]/index';
+import { getPostsFromProjectsSubdir, getAllProjects } from '../../lib/projects';
+
+/**
+ * Since projects are organized into their own directories, 
+ * we want to generate a test for each directory instead of
+ * hardcoding them for project names--and having to update code
+ * any time there is a change.
+ * 
+ * Note: This is very similar to the idea behind what Next.js's
+ * getStaticPaths() method does for generating static pages.
+ */
+it('renders each ProjectsSection page', () => {
+    // Retrieve all project directories
+    const projects = getAllProjects();
+
+    // Iterate over each project directory
+    projects.map(proj => {
+        // Retrieve the posts/content for each project
+        const projectPosts = getPostsFromProjectsSubdir(proj);
+
+        // Render the component, providing props for the iteration
+        const { container } = render(
+            <ProjectsSection 
+                projectTitle={proj} 
+                posts={projectPosts} />
+        );
+        expect(container).toMatchSnapshot();
+    })
+})

--- a/__tests__/pages/__snapshots__/[project]-index.snapshot.js.snap
+++ b/__tests__/pages/__snapshots__/[project]-index.snapshot.js.snap
@@ -1,0 +1,366 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders each ProjectsSection page 1`] = `
+<div>
+  <div>
+    <header
+      class="header"
+    >
+      <div
+        class="menuIcon"
+      >
+        <div />
+        <div />
+        <div />
+        
+      </div>
+      <h1
+        class="heading2Xl"
+      >
+        <a
+          class="colorInherit"
+          href="/"
+        >
+          Rushing Labs
+        </a>
+      </h1>
+      <div
+        class="navbarLinks"
+      >
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/blog"
+          >
+            Blog
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/projects"
+          >
+            Projects
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/docs"
+          >
+            Docs
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/about"
+          >
+            About
+          </a>
+        </h2>
+      </div>
+    </header>
+    <div
+      class="mainContent"
+    >
+      <div
+        class="container"
+      >
+        <h1>
+          Project: 
+          amortize
+        </h1>
+        <ul />
+      </div>
+      <div
+        class="backToHome"
+      >
+        <a
+          href="/"
+        >
+          ← Back to home
+        </a>
+      </div>
+      <a
+        href="https://plausible.io/rushinglabs.com"
+      >
+        RushingLabs - Analytics
+      </a>
+    </div>
+    
+  </div>
+</div>
+`;
+
+exports[`renders each ProjectsSection page 2`] = `
+<div>
+  <div>
+    <header
+      class="header"
+    >
+      <div
+        class="menuIcon"
+      >
+        <div />
+        <div />
+        <div />
+        
+      </div>
+      <h1
+        class="heading2Xl"
+      >
+        <a
+          class="colorInherit"
+          href="/"
+        >
+          Rushing Labs
+        </a>
+      </h1>
+      <div
+        class="navbarLinks"
+      >
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/blog"
+          >
+            Blog
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/projects"
+          >
+            Projects
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/docs"
+          >
+            Docs
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/about"
+          >
+            About
+          </a>
+        </h2>
+      </div>
+    </header>
+    <div
+      class="mainContent"
+    >
+      <div
+        class="container"
+      >
+        <h1>
+          Project: 
+          game-capture
+        </h1>
+        <ul>
+          <li>
+            <a
+              href="/projects/game-capture/intro"
+            >
+              Game Capture - a TikTok series
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div
+        class="backToHome"
+      >
+        <a
+          href="/"
+        >
+          ← Back to home
+        </a>
+      </div>
+      <a
+        href="https://plausible.io/rushinglabs.com"
+      >
+        RushingLabs - Analytics
+      </a>
+    </div>
+    
+  </div>
+</div>
+`;
+
+exports[`renders each ProjectsSection page 3`] = `
+<div>
+  <div>
+    <header
+      class="header"
+    >
+      <div
+        class="menuIcon"
+      >
+        <div />
+        <div />
+        <div />
+        
+      </div>
+      <h1
+        class="heading2Xl"
+      >
+        <a
+          class="colorInherit"
+          href="/"
+        >
+          Rushing Labs
+        </a>
+      </h1>
+      <div
+        class="navbarLinks"
+      >
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/blog"
+          >
+            Blog
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/projects"
+          >
+            Projects
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/docs"
+          >
+            Docs
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/about"
+          >
+            About
+          </a>
+        </h2>
+      </div>
+    </header>
+    <div
+      class="mainContent"
+    >
+      <div
+        class="container"
+      >
+        <h1>
+          Project: 
+          owasp
+        </h1>
+        <ul>
+          <li>
+            <a
+              href="/projects/owasp/a01-broken-access-control"
+            >
+              A01:2021 Broken Access Control
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a02-cryptographic-failures"
+            >
+              A02:2021 Cryptographic Failures
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a03-injection"
+            >
+              A03:2021 Injection
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a04-insecure-design"
+            >
+              A04:2021 Insecure Design
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a05-security-misconfiguration"
+            >
+              A05:2021 Security Misconfiguration
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a06-vulnerable-outdated-components"
+            >
+              A06:2021 Vulnerable and Outdated Components
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a07-identification-auth-failures"
+            >
+              A02:2021 Identification and Authentication Failures
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a08-software-data-integrity-failures"
+            >
+              A08:2021 Software and Data Integrity Failures
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a09-logging-monitoring-failures"
+            >
+              A09:2021 Security Logging and Monitoring Failures
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/a10-server-side-request-forgery"
+            >
+              A10:2021 Server Side Request Forgery (SSRF)
+            </a>
+          </li>
+          <li>
+            <a
+              href="/projects/owasp/intro"
+            >
+              Intro: Why Bother "Explaning" the Top 10?
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div
+        class="backToHome"
+      >
+        <a
+          href="/"
+        >
+          ← Back to home
+        </a>
+      </div>
+      <a
+        href="https://plausible.io/rushinglabs.com"
+      >
+        RushingLabs - Analytics
+      </a>
+    </div>
+    
+  </div>
+</div>
+`;

--- a/__tests__/pages/__snapshots__/about.snapshot.js.snap
+++ b/__tests__/pages/__snapshots__/about.snapshot.js.snap
@@ -92,7 +92,7 @@ exports[`renders About page unchanged 1`] = `
                     <img
                       alt=""
                       aria-hidden="true"
-                      src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
                       style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
                     />
                   </span>
@@ -118,7 +118,7 @@ exports[`renders About page unchanged 1`] = `
                     <img
                       alt=""
                       aria-hidden="true"
-                      src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
                       style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
                     />
                   </span>
@@ -144,7 +144,7 @@ exports[`renders About page unchanged 1`] = `
                     <img
                       alt=""
                       aria-hidden="true"
-                      src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
                       style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
                     />
                   </span>
@@ -170,7 +170,7 @@ exports[`renders About page unchanged 1`] = `
                     <img
                       alt=""
                       aria-hidden="true"
-                      src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
                       style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
                     />
                   </span>
@@ -196,7 +196,7 @@ exports[`renders About page unchanged 1`] = `
                     <img
                       alt=""
                       aria-hidden="true"
-                      src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%2730%27%20height=%2730%27/%3e"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
                       style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
                     />
                   </span>

--- a/__tests__/pages/__snapshots__/index.snapshot.js.snap
+++ b/__tests__/pages/__snapshots__/index.snapshot.js.snap
@@ -1,0 +1,363 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders homepage unchanged 1`] = `
+<div>
+  <div>
+    <header
+      class="header"
+    >
+      <div
+        class="menuIcon"
+      >
+        <div />
+        <div />
+        <div />
+        
+      </div>
+      <h1
+        class="heading2Xl"
+      >
+        <a
+          class="colorInherit"
+          href="/"
+        >
+          Rushing Labs
+        </a>
+      </h1>
+      <div
+        class="navbarLinks"
+        style="display: flex; flex-direction: row;"
+      >
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/blog"
+          >
+            Blog
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/projects"
+          >
+            Projects
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/docs"
+          >
+            Docs
+          </a>
+        </h2>
+        <h2>
+          <a
+            class="text-xl font-bold underline text-inherit"
+            href="/about"
+          >
+            About
+          </a>
+        </h2>
+      </div>
+    </header>
+    <div
+      class="container"
+    >
+      <div
+        class="heroImage"
+      >
+        <span
+          style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+        >
+          <span
+            style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjU2MCIgaGVpZ2h0PSI1MjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
+              style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+            />
+          </span>
+          <img
+            alt="Header image, computers on a desk"
+            data-nimg="intrinsic"
+            decoding="async"
+            src="/_next/image?url=https%3A%2F%2Fmeddlin-web.s3.us-east-2.amazonaws.com%2Flanding-page%2Fweb-header.webp&w=3840&q=75"
+            srcset="/_next/image?url=https%3A%2F%2Fmeddlin-web.s3.us-east-2.amazonaws.com%2Flanding-page%2Fweb-header.webp&w=3840&q=75 1x"
+            style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+          />
+          <noscript />
+        </span>
+      </div>
+      <div
+        class="content"
+      >
+        <div
+          class="summaries"
+        >
+          <p>
+            Hi! I'm Darrien, a software engineer and content creator based in Austin, TX.
+          </p>
+          <div>
+            <span
+              style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+            >
+              <span
+                style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTkyMCIgaGVpZ2h0PSIxMDgwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIvPg=="
+                  style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                />
+              </span>
+              <img
+                alt="author selfie"
+                data-nimg="intrinsic"
+                decoding="async"
+                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+              />
+              <noscript />
+            </span>
+          </div>
+          <p
+            class="summariesSecondary"
+          >
+            With over 8 years in the tech industry, I wanted to create a space to share what I've built, create tutorials to help others, and share some ideas for what I'd like to build in the future.
+          </p>
+        </div>
+        <div
+          class="videoScreenshot"
+        >
+          <a
+            href="https://www.youtube.com/c/RushingLabs"
+          >
+            <span
+              style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+            >
+              <span
+                style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTA0IiBoZWlnaHQ9IjM3OCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                />
+              </span>
+              <img
+                alt="artistic camera"
+                data-nimg="intrinsic"
+                decoding="async"
+                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+              />
+              <noscript />
+            </span>
+          </a>
+          <div
+            class="explanation"
+          >
+            <p>
+              <a
+                href="https://www.youtube.com/c/rushinglabs"
+              >
+                <b>
+                  Rushing Labs
+                </b>
+              </a>
+               on YouTube is where I create tutorials, and share my progress building projects.
+            </p>
+          </div>
+        </div>
+        <div
+          class="videoScreenshot"
+        >
+          <a
+            href="https://github.com/meddlin"
+          >
+            <span
+              style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+            >
+              <span
+                style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTEzIiBoZWlnaHQ9IjM0MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                />
+              </span>
+              <img
+                alt="artistic laptop"
+                data-nimg="intrinsic"
+                decoding="async"
+                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+              />
+              <noscript />
+            </span>
+          </a>
+          <div
+            class="leftExplanation"
+          >
+            <p>
+              My 
+              <a
+                href="https://github.com/meddlin"
+              >
+                <b>
+                  GitHub
+                </b>
+              </a>
+               profile is where you can find a majority of the rest of my online work.
+            </p>
+          </div>
+        </div>
+        <hr
+          style="width: 50%; margin: 2em;"
+        />
+        <div
+          class="blogPosts"
+        >
+          <span>
+            Check out my recent blog posts
+          </span>
+          <ul />
+        </div>
+        <div
+          class="footer"
+        >
+          <div
+            class="socialsBar"
+          >
+            <div>
+              <a
+                href="https://www.youtube.com/c/RushingLabs"
+              >
+                <span
+                  style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+                >
+                  <span
+                    style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+                  >
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
+                      style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                    />
+                  </span>
+                  <img
+                    data-nimg="intrinsic"
+                    decoding="async"
+                    src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                    style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+                  />
+                  <noscript />
+                </span>
+              </a>
+            </div>
+            <div>
+              <a
+                href="https://www.tiktok.com/@rushinglabs?lang=en"
+              >
+                <span
+                  style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+                >
+                  <span
+                    style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+                  >
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
+                      style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                    />
+                  </span>
+                  <img
+                    data-nimg="intrinsic"
+                    decoding="async"
+                    src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                    style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+                  />
+                  <noscript />
+                </span>
+              </a>
+            </div>
+            <div>
+              <a
+                href="https://github.com/meddlin"
+              >
+                <span
+                  style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+                >
+                  <span
+                    style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+                  >
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
+                      style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                    />
+                  </span>
+                  <img
+                    data-nimg="intrinsic"
+                    decoding="async"
+                    src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                    style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+                  />
+                  <noscript />
+                </span>
+              </a>
+            </div>
+            <div>
+              <a
+                href="https://twitter.com/meddlin_dev"
+              >
+                <span
+                  style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+                >
+                  <span
+                    style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+                  >
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmVyc2lvbj0iMS4xIi8+"
+                      style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                    />
+                  </span>
+                  <img
+                    data-nimg="intrinsic"
+                    decoding="async"
+                    src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                    style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+                  />
+                  <noscript />
+                </span>
+              </a>
+            </div>
+          </div>
+          <p>
+            Built with 
+            <a
+              href="https://nextjs.org/"
+              style="color: black; font-weight: bold;"
+            >
+              Next.js
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@next/mdx": "^13.0.3",
     "cross-env": "^7.0.3",
     "date-fns": "^2.17.0",
+    "escape-html": "^1.0.3",
     "gray-matter": "^4.0.2",
     "next": "^12.0.4",
     "prismjs": "^1.25.0",

--- a/pages/categories/owasp/index.js
+++ b/pages/categories/owasp/index.js
@@ -4,6 +4,7 @@ import Layout from '../../../components/layout';
 import { siteTitle } from '../../../components/layout-head-loader';
 import { getPostsFromDocsSubdir } from '../../../lib/posts';
 import config from '../../../blogConfig';
+import escapeHTML from 'escape-html';
 
 const _section_ = 'owasp';
 
@@ -38,7 +39,7 @@ export default function OwaspSection ({ posts }) {
                     {(posts && posts.length > 0) ? (
                         posts.map( ({id, year, date, title, preview}) => (
                             <li>
-                                <Link href={`/docs/${_section_}/${id}`}>
+                                <Link href={`/docs/${escapeHTML(_section_)}/${escapeHTML(id)}`}>
                                     <a>{id}</a>
                                 </Link>
                             </li>

--- a/pages/docs/[section]/index.js
+++ b/pages/docs/[section]/index.js
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Layout from '../../../components/layout';
 import utilStyles from '../../../styles/utils.module.css';
 import { getAllDocsSections, getPostsFromDocsSubdir } from '../../../lib/docs';
+import escapeHTML from 'escape-html';
 
 export async function getStaticProps({ params }) {
     /**
@@ -42,7 +43,7 @@ function DocsSection({ docs, section }) {
                 <ul>
                     {docs && docs.length > 0 ? docs.map( doc => (
                         <li key={doc.id}>
-                            <Link href={`/docs/${section}/${doc.id}`}>
+                            <Link href={`/docs/${escapeHTML(section)}/${escapeHTML(doc.id)}`}>
                                 <a>{doc.id}</a>
                             </Link>
                         </li>

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -1,3 +1,4 @@
+import escapeHTML from 'escape-html';
 import Head from 'next/head';
 import Link from 'next/link';
 import Layout from '../../components/layout';
@@ -52,14 +53,14 @@ function Docs({ docs, chunks, sections }) {
                 <ul className={docsStyles.listParent}>
                     {chunks.map( ({section, docs}) => (
                         <li key={section}>
-                            <Link href={`/docs/${section}`}>
+                            <Link href={`/docs/${escapeHTML(section)}`}>
                                 <a><h3>{section}</h3></a>
                             </Link>
                             {docs && docs.length > 0 ? (
                                 <ul className={utilStyles.list}>
                                     {docs.map( doc => (
                                         <li className={utilStyles.listItem} key={doc.id}>
-                                            <Link href={`/docs/${section}/${doc.id}`}>
+                                            <Link href={`/docs/${escapeHTML(section)}/${escapeHTML(doc.id)}`}>
                                                 <a>{doc.title}</a>
                                             </Link>
                                             <small className={utilStyles.subpreview}>

--- a/pages/projects/[project]/index.js
+++ b/pages/projects/[project]/index.js
@@ -1,3 +1,4 @@
+import escapeHTML from 'escape-html';
 import Layout from '../../../components/layout';
 import { getPostsFromProjectsSubdir, getAllProjects } from '../../../lib/projects';
 
@@ -35,7 +36,7 @@ const ProjectsSection = ({ projectTitle, posts }) => {
                 {
                     posts.map( post => (
                         <li key={post.title}>
-                            <a href={`/projects/${projectTitle}/${post.id}`}>
+                            <a href={`/projects/${escapeHTML(projectTitle)}/${escapeHTML(post.id)}`}>
                                 {post.title}
                             </a>
                         </li>

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -6,6 +6,7 @@ import Date from '../../components/date';
 import utilStyles from '../../styles/utils.module.css';
 import recipesStyles from '../../styles/recipes.module.css';
 import { getAllRecipesSections, getPostsFromRecipesSubdir, getSortedRecipesPostsData } from '../../lib/recipes';
+import escapeHTML from 'escape-html';
 
 export async function getStaticProps() {
     const recipesData = getSortedRecipesPostsData();
@@ -39,14 +40,14 @@ function Recipes({ docs, chunks, sections }) {
                 <ul className={recipesStyles.listParent}>
                     {chunks.map( ({section, docs}) => (
                         <li key={section}>
-                            <Link href={`/recipes/${section}`}>
+                            <Link href={`/recipes/${escapeHTML(section)}`}>
                                 <a><h3>{section}</h3></a>
                             </Link>
                             {docs && docs.length > 0 ? (
                                 <ul className={utilStyles.list}>
                                     {docs.map( doc => (
                                         <li className={utilStyles.listItem} key={doc.id}>
-                                            <Link href={`/recipes/${section}/${doc.id}`}>
+                                            <Link href={`/recipes/${escapeHTML(section)}/${escapeHTML(doc.id)}`}>
                                                 <a>{doc.title}</a>
                                             </Link>
                                             <small className={utilStyles.subpreview}>


### PR DESCRIPTION
Resolves #144 
Resolves #145 
Resolves #146 
Resolves #147
Resolves #148 
Resolves #130 
Resolves #131

## Fixing cross-site scripting vuln from CodeQL scan

- Escaping routing variables on project index page
- Created snapshot test for page, too

## Note on snapshot tests

Found out I'm able to generate snapshot tests for each "page" under a section. For parts of the site that have sub-routes, this means we aren't forced into hardcoding the "subsections" (or sub-routes) into individual tests. _Instead we can borrow the idea of Next.js's `getStaticPaths()` and generate the snapshot tests!&mdash;and this runs all the same with_ `npm run test`, _too!_

So the following code generates 3 tests, but is written as 1.

```js
import { render } from '@testing-library/react';
import ProjectsSection from '../../pages/projects/[project]/index';
import { getPostsFromProjectsSubdir, getAllProjects } from '../../lib/projects';

/**
 * Since projects are organized into their own directories, 
 * we want to generate a test for each directory instead of
 * hardcoding them for project names--and having to update code
 * any time there is a change.
 * 
 * Note: This is very similar to the idea behind what Next.js's
 * getStaticPaths() method does for generating static pages.
 */
it('renders each ProjectsSection page', () => {
    // Retrieve all project directories
    const projects = getAllProjects();

    // Iterate over each project directory
    projects.map(proj => {
        // Retrieve the posts/content for each project
        const projectPosts = getPostsFromProjectsSubdir(proj);

        // Render the component, providing props for the iteration
        const { container } = render(
            <ProjectsSection 
                projectTitle={proj} 
                posts={projectPosts} />
        );
        expect(container).toMatchSnapshot();
    })
})
```